### PR TITLE
파싱 가능한 마크다운 문법 확장 및 컴포넌트화

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -97,21 +97,8 @@
     @apply border-border;
   }
   *[contenteditable] {
-    @apply inline-block cursor-text focus:outline-none empty:after:content-[attr(placeholder)] empty:block empty:text-gray-300;
+    @apply inline-block cursor-text caret-black focus:outline-none empty:after:content-[attr(placeholder)] empty:block empty:text-gray-300;
   }
-  /* *[contenteditable] > ul {
-    @apply list-disc list-outside;
-  }
-  *[contenteditable] > ol {
-    @apply list-decimal list-outside;
-  }
-  code {
-    @apply px-2 py-1 my-2 bg-stone-100 text-red-500 rounded-lg;
-  }
-  blockquote {
-    @apply min-h-[3em] px-6 py-3 my-4 bg-gray-50 border-l-4 border-gray-300 text-lg font-medium;
-  } */
-
   body {
     @apply bg-background text-foreground;
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -99,18 +99,18 @@
   *[contenteditable] {
     @apply inline-block cursor-text focus:outline-none empty:after:content-[attr(placeholder)] empty:block empty:text-gray-300;
   }
-  *[contenteditable] > ul {
-    @apply list-disc list-inside;
+  /* *[contenteditable] > ul {
+    @apply list-disc list-outside;
   }
   *[contenteditable] > ol {
-    @apply list-decimal list-inside;
+    @apply list-decimal list-outside;
   }
   code {
     @apply px-2 py-1 my-2 bg-stone-100 text-red-500 rounded-lg;
   }
   blockquote {
-    @apply px-6 py-3 my-4 bg-gray-50 border-l-4 border-gray-300 text-lg font-medium;
-  }
+    @apply min-h-[3em] px-6 py-3 my-4 bg-gray-50 border-l-4 border-gray-300 text-lg font-medium;
+  } */
 
   body {
     @apply bg-background text-foreground;

--- a/src/components/playground/index.tsx
+++ b/src/components/playground/index.tsx
@@ -7,10 +7,10 @@ import { Textarea } from "../ui/textarea";
 import { Titlearea } from "../ui/titlearea";
 
 const Playground = () => {
-  const [textAreaValue, setTextAreaValue] = useState<string>();
-  const result = marked(textAreaValue || "");
-
   const [html, setHtml] = useState<string>();
+
+  const [textAreaValue, setTextAreaValue] = useState<string>();
+  const result = marked(textAreaValue || "", { async: false });
 
   const parseMarkdown = (markdown: string | undefined) => {
     const regex = /<[^>]*>?/g; // html 태그 정규식
@@ -47,7 +47,7 @@ const Playground = () => {
       {result}
       <div
         contentEditable
-        dangerouslySetInnerHTML={{ __html: result as string }}
+        dangerouslySetInnerHTML={{ __html: result }}
         className="w-full"
       />
       <Textarea
@@ -56,7 +56,6 @@ const Playground = () => {
           const value = e.target.value;
           console.log({ value: value });
           setTextAreaValue(value);
-          // setHtml(marked(value) as string);
         }}
         placeholder="글을 작성하거나 명령어를 사용하려면 '/' 키를 누르세요"
       />

--- a/src/components/playground/index.tsx
+++ b/src/components/playground/index.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import { marked } from "marked";
-import { ElementType, useCallback, useRef, useState } from "react";
-import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
+import { ElementType, useState } from "react";
+import Row from "../row";
 import { Textarea } from "../ui/textarea";
 import { Titlearea } from "../ui/titlearea";
 
 const Playground = () => {
   const [textAreaValue, setTextAreaValue] = useState<string>();
+  const result = marked(textAreaValue || "");
 
   const [html, setHtml] = useState<string>();
-  const contentEditableRef = useRef<HTMLElement>(null);
-
-  const result = marked(textAreaValue || "");
 
   const parseMarkdown = (markdown: string | undefined) => {
     const regex = /<[^>]*>?/g; // html 태그 정규식
@@ -43,72 +41,26 @@ const Playground = () => {
     } else return { tag: undefined, content: undefined };
   };
 
-  const addHTMLAttributes = (html: string | undefined) => {
-    return html
-      ? html.slice(0, html?.indexOf(">")) +
-          ` contenteditable placeholder="글을 작성하거나 명령어를 사용하려면 '/' 키를 누르세요"` +
-          html.slice(html?.indexOf(">"))
-      : "";
-  };
-
-  const onChangeContents = useCallback((event: ContentEditableEvent) => {
-    const regex = /<[^>]*>?/g; // html 태그 정규식
-
-    const value = event.target.value;
-    const htmlTag = value
-      .match(regex)
-      ?.at(0)
-      ?.replace("<", "")
-      .replace(">", "")
-      .split(" ")[0];
-
-    const content = value.replace(/<[^>]*>?/g, "");
-    const htmlString = marked(value);
-
-    const cursor = document.getSelection();
-    const offset = cursor?.anchorOffset;
-
-    if (typeof htmlString === "string") {
-      console.log({
-        html: htmlString,
-        tag: htmlTag,
-        content: content,
-        offset: offset,
-      });
-      if (!htmlTag) {
-        setHtml(addHTMLAttributes(htmlString));
-      } else if (htmlTag.includes("br")) {
-        setHtml(undefined);
-      } else {
-      }
-    }
-    // else htmlString.then((res) => setHtml(addHTMLAttributes(res)));
-  }, []);
-
   return (
     <div className="size-full p-2 space-y-4">
       <Titlearea placeholder="새 페이지" />
       {result}
+      <div
+        contentEditable
+        dangerouslySetInnerHTML={{ __html: result as string }}
+        className="w-full"
+      />
       <Textarea
         value={textAreaValue}
         onChange={(e) => {
           const value = e.target.value;
+          console.log({ value: value });
           setTextAreaValue(value);
           // setHtml(marked(value) as string);
         }}
         placeholder="글을 작성하거나 명령어를 사용하려면 '/' 키를 누르세요"
       />
-      <ContentEditable
-        placeholder={"글을 작성하거나 명령어를 사용하려면 '/' 키를 누르세요"}
-        html={html || ""}
-        innerRef={contentEditableRef}
-        onChange={onChangeContents}
-        className={
-          contentEditableRef.current?.innerText.length === 0
-            ? "w-full"
-            : "w-full content-[attr(placeholder)] block text-gray-300"
-        }
-      />
+      <Row innerHtml={html} setInnerHtml={setHtml} />
     </div>
   );
 };

--- a/src/components/row/index.tsx
+++ b/src/components/row/index.tsx
@@ -55,9 +55,10 @@ const Row = ({ innerHtml, setInnerHtml }: Props) => {
     [setInnerHtml]
   );
 
-  const placeholderStyle = "content-[attr(placeholder)]";
+  const placeholderStyle = "w-fit content-[attr(placeholder)]";
   const ulStyle = "[&_ul]:list-disc";
-  const olStyle = "[&_ol]:list-decimal";
+  const olStyle = "[&_ol]:list-decimal ";
+  const liStyle = "[&_li]:my-2 [&_li]:ml-6";
   const codeStyle =
     "[&_code]:px-2 [&_code]:py-1 [&_code]:my-2 [&_code]:bg-stone-100 [&_code]:text-red-500 [&_code]:rounded-lg";
   const blockquoteStyle =
@@ -71,7 +72,7 @@ const Row = ({ innerHtml, setInnerHtml }: Props) => {
         onChange={onChangeContents}
         className={
           innerHtml
-            ? twMerge(ulStyle, olStyle, codeStyle, blockquoteStyle)
+            ? twMerge(ulStyle, olStyle, liStyle, codeStyle, blockquoteStyle)
             : placeholderStyle
         }
       />

--- a/src/components/row/index.tsx
+++ b/src/components/row/index.tsx
@@ -1,0 +1,82 @@
+import { marked } from "marked";
+import { Dispatch, SetStateAction, useCallback, useRef } from "react";
+import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
+import { twMerge } from "tailwind-merge";
+
+type Props = {
+  innerHtml: string | undefined;
+  setInnerHtml: Dispatch<SetStateAction<string | undefined>>;
+};
+
+const Row = ({ innerHtml, setInnerHtml }: Props) => {
+  const contentEditableRef = useRef<HTMLElement>(null);
+
+  const addHTMLAttributes = (html: string | undefined) => {
+    return html
+      ? `${html.slice(0, html?.indexOf(">"))} contenteditable placeholder="글을 작성하거나 명령어를 사용하려면 '/' 키를 누르세요"${html.slice(html?.indexOf(">"))}`
+      : "";
+  };
+
+  const onChangeContents = useCallback(
+    (event: ContentEditableEvent) => {
+      const regex = /<[^>]*>?/g; // html 태그 정규식
+
+      const value = event.target.value;
+      const htmlTag = value
+        .match(regex)
+        ?.at(0)
+        ?.replace("<", "")
+        .replace(">", "")
+        .split(" ")[0];
+
+      const content = value.replace(/<[^>]*>?/g, "").replace("|", ">");
+      const htmlString = marked(content);
+
+      const cursor = document.getSelection();
+      const offset = cursor?.anchorOffset;
+
+      console.log({
+        value: value,
+        html: htmlString,
+        tag: htmlTag,
+        content: content,
+        offset: offset,
+      });
+      if (!htmlTag) {
+        if (typeof htmlString === "string")
+          setInnerHtml(addHTMLAttributes(htmlString));
+        // else htmlString.then((res) => setInnerHtml(addHTMLAttributes(res)));
+      } else if (htmlTag.includes("br")) {
+        setInnerHtml(undefined);
+      } else if (htmlTag.includes("div")) {
+        setInnerHtml(undefined);
+      }
+    },
+    [setInnerHtml]
+  );
+
+  const placeholderStyle = "content-[attr(placeholder)]";
+  const ulStyle = "[&_ul]:list-disc";
+  const olStyle = "[&_ol]:list-decimal";
+  const codeStyle =
+    "[&_code]:px-2 [&_code]:py-1 [&_code]:my-2 [&_code]:bg-stone-100 [&_code]:text-red-500 [&_code]:rounded-lg";
+  const blockquoteStyle =
+    "[&_blockquote]:min-h-[3em] [&_blockquote]:px-6 [&_blockquote]:py-3 [&_blockquote]:my-4 [&_blockquote]:bg-gray-50 [&_blockquote]:border-l-4 [&_blockquote]:border-gray-300 [&_blockquote]:text-lg [&_blockquote]:font-medium";
+
+  return (
+    <div className="w-full mx-3">
+      <ContentEditable
+        placeholder={"글을 작성하거나 명령어를 사용하려면 '/' 키를 누르세요"}
+        html={innerHtml || ""}
+        onChange={onChangeContents}
+        className={
+          innerHtml
+            ? twMerge(ulStyle, olStyle, codeStyle, blockquoteStyle)
+            : placeholderStyle
+        }
+      />
+    </div>
+  );
+};
+
+export default Row;

--- a/src/components/row/index.tsx
+++ b/src/components/row/index.tsx
@@ -21,36 +21,36 @@ const Row = ({ innerHtml, setInnerHtml }: Props) => {
     (event: ContentEditableEvent) => {
       const regex = /<[^>]*>?/g; // html 태그 정규식
 
-      const value = event.target.value;
-      const htmlTag = value
+      const innerHtmlvalue = event.target.value;
+      const type = innerHtmlvalue
         .match(regex)
         ?.at(0)
         ?.replace("<", "")
         .replace(">", "")
         .split(" ")[0];
-
-      const content = value.replace(/<[^>]*>?/g, "").replace("|", ">");
-      const htmlString = marked(content);
-
+      const content = innerHtmlvalue.replace(/<[^>]*>?/g, "").replace("|", ">");
       const cursor = document.getSelection();
       const offset = cursor?.anchorOffset;
 
       console.log({
-        value: value,
-        html: htmlString,
-        tag: htmlTag,
+        innerHtml: innerHtmlvalue,
+        type: type,
         content: content,
         offset: offset,
       });
-      if (!htmlTag) {
-        if (typeof htmlString === "string")
-          setInnerHtml(addHTMLAttributes(htmlString));
-        // else htmlString.then((res) => setInnerHtml(addHTMLAttributes(res)));
-      } else if (htmlTag.includes("br")) {
-        setInnerHtml(undefined);
-      } else if (htmlTag.includes("div")) {
-        setInnerHtml(undefined);
-      }
+
+      if (
+        content.includes(" ") ||
+        content.includes("```") ||
+        content.includes("---")
+      ) {
+        const parsedHtml = marked(content, { async: false });
+        console.log(parsedHtml);
+        if (!type) setInnerHtml(addHTMLAttributes(parsedHtml));
+        else if (type.includes("br") || type.includes("div")) {
+          setInnerHtml(undefined);
+        }
+      } else if (!content) setInnerHtml(undefined);
     },
     [setInnerHtml]
   );


### PR DESCRIPTION
# 기능 설명
- 두 개 이상의 기호에 대한 매크다운 밀부 문법을 html로 파싱하여 출력
- 컴포넌트 분리

## 기능 구현
- 최초 입력 상태에서만 적용 가능

### 가능한 MD 문법 기호
- '#', '##', '###' : 제목
-  '*', '-', '1.' : 리스트
- '|' : 인용, 원래 마크다운 문법으로는 '>'를 사용하지만 직관성을 위해 대체, 노션도 동일
- '---' : hr
- '```' : code