### PR TITLE
Dynamic Contenteditable Mutable Row Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm run dev
 npm run start
 ```
 
-Open [http://localhost:3000](http://localhost:3300) with your browser to see the result.
+Open [http://localhost:3300](http://localhost:3300) with your browser to see the result.
 
 # Skills
 

--- a/src/components/playground/index.tsx
+++ b/src/components/playground/index.tsx
@@ -1,24 +1,50 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, KeyboardEvent } from "react";
 import Row from "../row";
 import { Titlearea } from "../ui/titlearea";
 
 const Playground = () => {
   const [htmlData, setHtmlData] = useState<(string | undefined)[]>([undefined]);
+  const [code, setCode] = useState("");
 
   const addRow = useCallback(() => {
     setHtmlData([...htmlData, undefined]);
+    setCode("");
   }, [htmlData]);
 
-  const subtractRow = useCallback(() => {
-    if (htmlData.length > 1) {
-      const temp = htmlData.slice(0, -1);
-      setHtmlData(temp);
-    }
-  }, [htmlData]);
+  const subtractRow = useCallback(
+    (index: number) => {
+      if (htmlData.length > 1)
+        setHtmlData(htmlData.filter((_, i) => i !== index));
+    },
+    [htmlData]
+  );
 
-  useEffect(() => console.log(htmlData), [htmlData]);
+  const handleKeydown = useCallback(
+    (e: KeyboardEvent<HTMLElement>, index: number) => {
+      if (e.currentTarget === e.target && e.nativeEvent.isComposing === false) {
+        const code = e.code.toLowerCase();
+        if (code === "enter") {
+          e.preventDefault();
+          setCode("Add");
+        } else if (code === "backspace") {
+          const text = e.currentTarget.innerText;
+          const cursor = document.getSelection();
+          const offset = cursor?.anchorOffset;
+          // setCode("Sub");
+          setCode("");
+          if (offset === 0 && text === "") subtractRow(index);
+        } else setCode("");
+      }
+    },
+    [subtractRow]
+  );
+
+  useEffect(() => {
+    if (code === "Add") setTimeout(() => addRow(), 0);
+    // else if (code === "Sub") setTimeout(() => subtractRow(), 0);
+  }, [addRow, code, subtractRow]);
 
   return (
     <div className="size-full p-2 space-y-4">
@@ -32,10 +58,7 @@ const Playground = () => {
             temp[index] = value;
             setHtmlData(temp);
           }}
-          addRow={addRow}
-          subtractRow={() => {
-            if (!html) subtractRow();
-          }}
+          onKeydown={(e) => handleKeydown(e, index)}
         />
       ))}
     </div>

--- a/src/components/playground/index.tsx
+++ b/src/components/playground/index.tsx
@@ -6,17 +6,18 @@ import { Titlearea } from "../ui/titlearea";
 
 const Playground = () => {
   const [htmlData, setHtmlData] = useState<(string | undefined)[]>([undefined]);
-  const [code, setCode] = useState("");
+  const [keycode, setKeyCode] = useState("");
 
   const addRow = useCallback(() => {
     setHtmlData([...htmlData, undefined]);
-    setCode("");
+    setKeyCode("");
   }, [htmlData]);
 
   const subtractRow = useCallback(
     (index: number) => {
       if (htmlData.length > 1)
         setHtmlData(htmlData.filter((_, i) => i !== index));
+      setKeyCode("");
     },
     [htmlData]
   );
@@ -27,24 +28,23 @@ const Playground = () => {
         const code = e.code.toLowerCase();
         if (code === "enter") {
           e.preventDefault();
-          setCode("Add");
+          setKeyCode("Add");
         } else if (code === "backspace") {
           const text = e.currentTarget.innerText;
           const cursor = document.getSelection();
           const offset = cursor?.anchorOffset;
-          // setCode("Sub");
-          setCode("");
-          if (offset === 0 && text === "") subtractRow(index);
-        } else setCode("");
+          if (offset === 0 && text === "") setKeyCode(`Sub${index}`);
+        }
       }
     },
-    [subtractRow]
+    []
   );
 
   useEffect(() => {
-    if (code === "Add") setTimeout(() => addRow(), 0);
-    // else if (code === "Sub") setTimeout(() => subtractRow(), 0);
-  }, [addRow, code, subtractRow]);
+    if (keycode === "Add") setTimeout(() => addRow(), 0);
+    else if (keycode.includes("Sub"))
+      setTimeout(() => subtractRow(Number(keycode.replace("Sub", ""))), 0);
+  }, [addRow, keycode, subtractRow]);
 
   return (
     <div className="size-full p-2 space-y-4">

--- a/src/components/playground/index.tsx
+++ b/src/components/playground/index.tsx
@@ -1,16 +1,43 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Row from "../row";
 import { Titlearea } from "../ui/titlearea";
 
 const Playground = () => {
-  const [html, setHtml] = useState<string>();
+  const [htmlData, setHtmlData] = useState<(string | undefined)[]>([undefined]);
+
+  const addRow = useCallback(() => {
+    setHtmlData([...htmlData, undefined]);
+  }, [htmlData]);
+
+  const subtractRow = useCallback(() => {
+    if (htmlData.length > 1) {
+      const temp = htmlData.slice(0, -1);
+      setHtmlData(temp);
+    }
+  }, [htmlData]);
+
+  useEffect(() => console.log(htmlData), [htmlData]);
 
   return (
     <div className="size-full p-2 space-y-4">
       <Titlearea placeholder="새 페이지" />
-      <Row innerHtml={html} setInnerHtml={setHtml} />
+      {htmlData.map((html, index) => (
+        <Row
+          key={index}
+          innerHtml={html}
+          setInnerHtml={(value: string | undefined) => {
+            const temp = [...htmlData];
+            temp[index] = value;
+            setHtmlData(temp);
+          }}
+          addRow={addRow}
+          subtractRow={() => {
+            if (!html) subtractRow();
+          }}
+        />
+      ))}
     </div>
   );
 };

--- a/src/components/playground/index.tsx
+++ b/src/components/playground/index.tsx
@@ -1,65 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useState, KeyboardEvent } from "react";
+import { useState } from "react";
 import Row from "../row";
 import { Titlearea } from "../ui/titlearea";
 
 const Playground = () => {
-  const [htmlData, setHtmlData] = useState<(string | undefined)[]>([undefined]);
-  const [keycode, setKeyCode] = useState("");
-
-  const addRow = useCallback(() => {
-    setHtmlData([...htmlData, undefined]);
-    setKeyCode("");
-  }, [htmlData]);
-
-  const subtractRow = useCallback(
-    (index: number) => {
-      if (htmlData.length > 1)
-        setHtmlData(htmlData.filter((_, i) => i !== index));
-      setKeyCode("");
-    },
-    [htmlData]
-  );
-
-  const handleKeydown = useCallback(
-    (e: KeyboardEvent<HTMLElement>, index: number) => {
-      if (e.currentTarget === e.target && e.nativeEvent.isComposing === false) {
-        const code = e.code.toLowerCase();
-        if (code === "enter") {
-          e.preventDefault();
-          setKeyCode("Add");
-        } else if (code === "backspace") {
-          const text = e.currentTarget.innerText;
-          const cursor = document.getSelection();
-          const offset = cursor?.anchorOffset;
-          if (offset === 0 && text === "") setKeyCode(`Sub${index}`);
-        }
-      }
-    },
-    []
-  );
-
-  useEffect(() => {
-    if (keycode === "Add") setTimeout(() => addRow(), 0);
-    else if (keycode.includes("Sub"))
-      setTimeout(() => subtractRow(Number(keycode.replace("Sub", ""))), 0);
-  }, [addRow, keycode, subtractRow]);
+  const [rows, setRows] = useState<(string | undefined)[]>([undefined]);
 
   return (
     <div className="size-full p-2 space-y-4">
       <Titlearea placeholder="새 페이지" />
-      {htmlData.map((html, index) => (
-        <Row
-          key={index}
-          innerHtml={html}
-          setInnerHtml={(value: string | undefined) => {
-            const temp = [...htmlData];
-            temp[index] = value;
-            setHtmlData(temp);
-          }}
-          onKeydown={(e) => handleKeydown(e, index)}
-        />
+      {rows.map((_, index) => (
+        <Row key={index} id={index} data={rows} setData={setRows} />
       ))}
     </div>
   );

--- a/src/components/row/index.tsx
+++ b/src/components/row/index.tsx
@@ -6,11 +6,10 @@ import { twMerge } from "tailwind-merge";
 type Props = {
   innerHtml: string | undefined;
   setInnerHtml: (result: string | undefined) => void;
-  addRow: () => void;
-  subtractRow: () => void;
+  onKeydown?: (e: KeyboardEvent<HTMLElement>) => void;
 };
 
-const Row = ({ innerHtml, setInnerHtml, addRow, subtractRow }: Props) => {
+const Row = ({ innerHtml, setInnerHtml, onKeydown }: Props) => {
   const [contentOffset, setContentOffset] = useState<number>();
   // string html 태그에 속성 추가
   const addHTMLAttributes = (html: string) => {
@@ -34,7 +33,7 @@ const Row = ({ innerHtml, setInnerHtml, addRow, subtractRow }: Props) => {
     (event: ContentEditableEvent) => {
       const regexAllTag = /<[^>]*>?/g; // html의 모든 태그 정규식
 
-      const currentHtmlvalue = event.target.value.replaceAll("<br>", "");
+      const currentHtmlvalue = event.target.value;
       const type = getHTMLtagName(currentHtmlvalue);
       const content = currentHtmlvalue.replace(regexAllTag, "");
       const cursor = document.getSelection();
@@ -68,21 +67,15 @@ const Row = ({ innerHtml, setInnerHtml, addRow, subtractRow }: Props) => {
         setInnerHtml(addHTMLAttributes(parsedHtml));
       else setInnerHtml(currentHtmlvalue);
 
-      console.log({
-        tag: type,
-        content: currentHtmlvalue,
-        offset: offset,
-        result: innerHtml,
-      });
+      // console.log({
+      //   tag: type,
+      //   content: currentHtmlvalue,
+      //   offset: offset,
+      //   result: innerHtml,
+      // });
     },
-    [innerHtml, setInnerHtml, setContentOffset]
+    [setInnerHtml, setContentOffset]
   );
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Enter" && contentOffset === undefined) addRow();
-    else if (e.key === "Backspace" && contentOffset === undefined)
-      subtractRow();
-  };
 
   const placeholderStyle = "content-[attr(placeholder)]";
   const hrStyle = "";
@@ -102,7 +95,7 @@ const Row = ({ innerHtml, setInnerHtml, addRow, subtractRow }: Props) => {
         placeholder={"글을 작성하거나 마크다운 텍스트를 입력하세요"}
         html={innerHtml || ""}
         onChange={onChangeContents}
-        onKeyDown={handleKeyDown}
+        onKeyDown={onKeydown}
         className={twMerge(
           `w-full space-y-2`,
           innerHtml

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
   "include": [
     "next-env.d.ts",
     "svgr.d.ts",
+    "someFile.d.ts",
     "src/**/*.ts",
     "lib/**/*.ts",
     "src/**/*.tsx",


### PR DESCRIPTION
# 기능 설명
- #3 컴포넌트에서 확장하여 키입력 이벤트 구현
- Enter 입력 시 현재 커서 위치 다음에 비어있는 Row 추가
- Backspace 입력 시 현재 커서가 위치한 Row 삭제

## 기능 상세
- 기존에 단일 string으로 받던 props를 리스트로 수정
- onChange event와 onKeydown event가 관리하는 상태들이 서로 연동되지 않아서 useEffect로 묶어서 업데이트 하도록 수정

## 이후 구현
1. 한글 입력 디버그 필요: "아"를 입력하면 "ㅇ아"로 출력, 해당 버그는 비어있는 상태에서 최초 입력 시에만 발생
2. Row 추가 및 삭제 시 커서(focus) 이동 구현